### PR TITLE
Add command to clean cache and build data

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,18 @@ If you want to update the frontend, you can do so via:
 
 - `yarn site`
 
-If you want to clear the cached data to start from a clean slate, you can do so via:
+If you want to clear the cached data, you can do so via:
 
 - `yarn clean` 
+
+Running `yarn clean` is a good idea if any plugins fail to load.
+
+If you want to restart from a clean slate and remove all the generated graphs, you can do so via:
+
+- `yarn clean-all` 
+
+Run `yarn clean-all` if the `yarn graph` command fails due to a change in the config or breaking changes in a new version of SourceCred.
+**Warning**: If you don't have credentials for every plugin, you might not be able to regenerate parts of the graph.
 
 [Yarn]: https://classic.yarnpkg.com/
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ If you want to update the frontend, you can do so via:
 
 - `yarn site`
 
+If you want to clear the cached data to start from a clean slate, you can do so via:
+
+- `yarn clean` 
+
 [Yarn]: https://classic.yarnpkg.com/
 
 # Publishing on GitHub pages

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "sourcecred": "0.7.0-beta-4"
   },
   "scripts": {
-    "clean": "rimraf cache output site",
+    "clean": "rimraf cache site",
+    "clean-all": "yarn clean && rimraf output",
     "load": "sourcecred load",
     "graph": "sourcecred graph",
     "score": "sourcecred score",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,13 @@
     "sourcecred": "0.7.0-beta-4"
   },
   "scripts": {
+    "clean": "rimraf cache output site",
     "load": "sourcecred load",
     "graph": "sourcecred graph",
     "score": "sourcecred score",
     "site": "sourcecred site"
+  },
+  "devDependencies": {
+    "rimraf": "^3.0.2"
   }
 }


### PR DESCRIPTION
Sometimes the cached data gets in a bad state which causes the sourcecred commands to fail.
This adds a command to package.json to make it easy for the user to wipe the cache, site and output folders
rimraf is used for cross-platform compatibility (i.e. Windows)

Test Plan: Run `yarn clean` and make sure the cache, output and site directories are deleted